### PR TITLE
For historic reasons we want to pick the user recorded against the re…

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -202,8 +202,14 @@ class Revision extends Eloquent
 
     public function getRevisionableName()
     {
-        if (Auth::check()) {
-            return Auth::user()->name;
+        $user = $this->userResponsible();
+
+        if (! $user && Auth::check()) {
+            $user = Auth::user();
+        }
+
+        if ($user) {
+            return $user->name;
         }
 
         return 'SYSTEM';


### PR DESCRIPTION
…cord, but if creating then safe to take the authed user