### PR TITLE
APX-4473 Comment out the name and description fields

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -194,8 +194,9 @@ class Revision extends Eloquent
     {
         $this->fill($revisionData);
 
-        $this->name = $this->getRevisionableName();
-        $this->description = $this->getRevisionableDescription();
+        // Comment out as the related fields are not being eager loaded, so this is causing additional lookups against the writer DB
+//        $this->name = $this->getRevisionableName();
+//        $this->description = $this->getRevisionableDescription();
 
         $this->save();
     }


### PR DESCRIPTION
Additional fields are causing additional lookups each time a model is written on the writer database.